### PR TITLE
fix: Correct TypeScript definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -456,6 +456,8 @@ declare namespace SendGrid {
     export interface SendGridConstructor {
         (apiKey: string, host?: string, globalHeaders?: { [header: string]: string; }): SendGrid;
         constructor(apiKey: string, host?: string, globalHeaders?: { [header: string]: string; }): SendGrid;
+
+        mail: SendGrid.Helpers.Mail.Helper;
     }
 
     export class SendGrid {
@@ -467,6 +469,5 @@ declare namespace SendGrid {
     }
 }
 
-declare const mail: SendGrid.Helpers.Mail.Helper;
 declare const sendGrid: SendGrid.SendGridConstructor;
-export {mail, sendGrid as SendGrid};
+export = sendGrid;


### PR DESCRIPTION
See #251 and https://github.com/SPARTAN563/sendgrid-ts-demo/pull/1 for more details on what wasn't working.

This ensures that the following code works correctly:

``` typescript
import * as SendGrid from "sendgrid";

const sendGrid = SendGrid("MYAPIKEY");
``
```
